### PR TITLE
patch to make lib work in IE7/8

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -611,7 +611,9 @@ Markdown.dialects.Gruber = {
           // Deal with code blocks or properly nested lists
           if (contained.length > 0) {
             // Make sure all listitems up the stack are paragraphs
-            stack.forEach( paragraphify, this );
+            for (var i = 0, l = stack.length; i < l; i++) {
+              paragraphify.call(this, stack[i]);
+            }
 
             last_li.push.apply( last_li, this.toTree( contained, [] ) );
           }
@@ -630,7 +632,9 @@ Markdown.dialects.Gruber = {
             }
 
             // Make sure all listitems up the stack are paragraphs
-            stack.forEach( paragraphify , this );
+            for (var i = 0, l = stack.length; i < l; i++) {
+              paragraphify.call(this, stack[i]);
+            }
 
             loose = true;
             continue loose_search;
@@ -764,7 +768,9 @@ Markdown.dialects.Gruber.inline = {
         re.lastIndex += ( len - m[2].length );
 
         // Add children
-        res.forEach(add);
+        for (var i = 0, l = res.length; i < l; i++) {
+          add(res[i]);
+        }
 
         lastIndex = re.lastIndex;
       }
@@ -1090,7 +1096,7 @@ Markdown.dialects.Maruku.block.block_meta = function block_meta( block, next ) {
 
 Markdown.dialects.Maruku.block.definition_list = function definition_list( block, next ) {
   // one or more terms followed by one or more definitions, in a single block
-  var tight = /^((?:[^\s:].*\n)+):\s+([^]+)$/,
+  var tight = /^((?:[^\s:].*\n)+):\s+([\^]+)$/,
       list = [ "dl" ];
 
   // see if we're dealing with a tight or loose block
@@ -1165,9 +1171,9 @@ Markdown.dialects.Maruku.inline[ "{:" ] = function inline_meta( text, matches, o
 Markdown.buildBlockOrder ( Markdown.dialects.Maruku.block );
 Markdown.buildInlinePatterns( Markdown.dialects.Maruku.inline );
 
-var isArray = expose.isArray = function(obj) {
-    return (obj instanceof Array || typeof obj === "array" || Array.isArray(obj));
-}
+var isArray = Array.isArray || function(obj) {
+  return Object.prototype.toString.call(obj) == '[object Array]';
+};
 
 function extract_attr( jsonml ) {
   return isArray(jsonml)


### PR DESCRIPTION
Just sharing a patch... markdown.js was failing in IE7/8 on a project I've been working on. I had to quickly make some patches for IE7/8 users because a js error was being thrown: http://dl.dropbox.com/u/385855/Screenshots/8k3z.png

Please note that the following tests are not passing (mostly edge cases). I've not yet had the time to fix but I could try. Please let me know if you have any suggestions as to how I could refactor to get everything green again?

https://gist.github.com/5cddc20d3bb395698a84

Thanks for the great library!
