### PR TITLE
compatibility with InDesign-flavored Javascript

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1198,8 +1198,8 @@ function process_meta_hash( meta_string ) {
       }
     }
     // attribute: foo=bar
-    else if ( /=/.test( meta[ i ] ) ) {
-      var s = meta[ i ].split( /=/ );
+    else if ( /\=/.test( meta[ i ] ) ) {
+      var s = meta[ i ].split( /\=/ );
       attr[ s[ 0 ] ] = s[ 1 ];
     }
   }


### PR DESCRIPTION
Hello,

I'm trying to port your script to InDesign-flavored Javascript. I think it would be really useful for a lot of people who are working in publishing contexts where they have to translate stuff back and forth between web and print.

I found to my delight that in basic cases, your script actually works out of the box, with one very tiny change: equals signs need to be escaped in regular expressions.

Then all that is necessary is to implement the ES5 forEach and isArray methods (easiest is to take the versions from the Mozilla Developer Network site) and then create a simple wrapper script, like

```
var exports = {};   
#include markdown.js   
var Markdown = exports.Markdown;
```

Then simple paragraphs are parsed fine. More complicated edge cases fail, unfortunately. The fixing of these bugs will probably necessitate changing your code so that it will break for users of the web and Node, and then I'd have to maintain a separate version, but hopefully not. I'll let you know.

In the meantime, if you could put this little change in with the equals signs, then other InDesign users who came across it would be able to tinker with it easily. I'll also send them your way.

Richard
