### PR TITLE
Correctly render void tags. Fixes #28, fixes #35

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1312,7 +1312,11 @@ function render_tree( jsonml ) {
   }
 
   // be careful about adding whitespace here for inline elements
-  return "<"+ tag + tag_attrs + ">" + content.join( "" ) + "</" + tag + ">";
+  if ( tag == "img" || tag == "br" || tag == "hr" ) {
+    return "<"+ tag + tag_attrs + "/>"
+  } else {
+    return "<"+ tag + tag_attrs + ">" + content.join( "" ) + "</" + tag + ">";
+  }
 }
 
 function convert_tree_to_html( tree, references, options ) {


### PR DESCRIPTION
Also, fixes the similar problem with `<hr/>` (it's now incorrectly inserted as `<hr></hr>`).
