### PR TITLE
processing stdin with md2html

### DIFF
--- a/bin/md2html.js
+++ b/bin/md2html.js
@@ -5,26 +5,35 @@
   var fs = require('fs')
     , markdown = require('markdown').markdown
     , fullpath = process.argv[2]
+    , stream
+    , buffer = ""
     ;
 
-  function convert(err, data) {
-    var md
-      , html
-      ;
+  if (fullpath == '--help') {
+    console.warn('usage:', process.argv[1].split('/').pop(), '/path/to/doc.md');
+    process.exit();
+  }
 
-    if (err) {
-      throw err;
-    }
+  if (fullpath) {
+    stream = fs.createReadStream(fullpath);
+  } else {
+    stream = process.stdin;
+  }
+  stream.resume();
+  stream.setEncoding('utf8');
 
-    md = data.toString('utf8');
-    html = markdown.toHTML(md);
+  stream.on('error', function(error) {
+    console.error(error.toString());
+    process.exit(1);
+  });
+
+  stream.on('data', function(data) {
+    buffer += data;
+  });
+
+  stream.on('end', function() {
+    var html = markdown.toHTML(buffer);
     console.log(html);
-  }
+  });
 
-  if (!fullpath) {
-    console.error('try: ', process.argv[1].split('/').pop(), '/path/to/doc.md');
-    return;
-  }
-
-  fs.readFile(fullpath, convert);
 }())


### PR DESCRIPTION
I expected from `md2html` to work with pipes like that: `echo "*test*" | md2html`. Currently I should create a temporary file for that which is annoying a lot.

This patch fixed this.
