### PR TITLE
fix for bug #24 (implicit conversion to a string)

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -666,7 +666,7 @@ Markdown.dialects.Gruber = {
       // if the next block is also a blockquote merge it in
       while ( next.length && next[ 0 ][ 0 ] == ">" ) {
         var b = next.shift();
-        block += block.trailing + b;
+        block = new String(block + block.trailing + b);
         block.trailing = b.trailing;
       }
 

--- a/test/features/blockquotes/threequotes.json
+++ b/test/features/blockquotes/threequotes.json
@@ -1,0 +1,7 @@
+[ "html",
+  [ "blockquote", 
+	[ "p", "this is" ], 
+	[ "p", "three" ], 
+	[ "p", "quotes" ]
+  ]
+]

--- a/test/features/blockquotes/threequotes.text
+++ b/test/features/blockquotes/threequotes.text
@@ -1,0 +1,5 @@
+> this is
+
+> three
+
+> quotes


### PR DESCRIPTION
I wonder what javascript engine this module was developed for?

In V8 you can't assign a property to a string. That's why bug #24 appears with Node.js:

``` javascript
var x = new String("test");
x.prop = "hi";
// x == 'test'
// x.prop == 'hi'

x += 'test'
// x == 'testtest'
// x.prop == undefined

x.prop = 'hi'
// x.prop == undefined
// (it's a string now, not an object, it's immutable now)
```
