### PR TITLE
Fix bug in numbered lists

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -414,7 +414,7 @@ Markdown.dialects.Gruber = {
     //
     lists: (function( ) {
       // Use a closure to hide a few variables.
-      var any_list = "[*+-]|\\d\\.",
+      var any_list = "[*+-]|\\d+\\.",
           bullet_list = /[*+-]/,
           number_list = /\d+\./,
           // Capture leading indent as it matters for determining nested lists.


### PR DESCRIPTION
Fixed issue where numbered lists with numbered prefixes greater than 9 (eg: 10. tenth item) are not parsed
