### PR TITLE
Enable spaces in a link/image url

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -814,7 +814,7 @@ Markdown.dialects.Gruber.inline = {
 
       // ![Alt text](/path/to/img.jpg "Optional title")
       //      1          2            3       4         <--- captures
-      var m = text.match( /^!\[(.*?)\][ \t]*\([ \t]*(\S*)(?:[ \t]+(["'])(.*?)\3)?[ \t]*\)/ );
+      var m = text.match( /^!\[(.*?)\][ \t]*\([ \t]*([^("|\))]*)(?:[ \t]+(["'])(.*?)\3)?[ \t]*\)/ );
 
       if ( m ) {
         if ( m[2] && m[2][0] == '<' && m[2][m[2].length-1] == '>' )
@@ -866,7 +866,7 @@ Markdown.dialects.Gruber.inline = {
       // back based on if there a matching ones in the url
       //    ([here](/url/(test))
       // The parens have to be balanced
-      var m = text.match( /^\s*\([ \t]*(\S+)(?:[ \t]+(["'])(.*?)\2)?[ \t]*\)/ );
+      var m = text.match( /^\s*\([ \t]*([^("|\))]*)(?:[ \t]+(["'])(.*?)\2)?[ \t]*\)/ );
       if ( m ) {
         var url = m[1];
         consumed += m[0].length;


### PR DESCRIPTION
Changed the regular expression for handling links and images, whitespaces are now allowed in a link url or image url. GitHub allows this, so it seems legit to change…

`[link text](Link to file/Lorem Ipsum.txt "Alt2")` is [link text](Link to file/Lorem Ipsum.txt)
