### PR TITLE
Don't allow unsafe URIs

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -8,12 +8,12 @@
   //Just a little helper to check if the URI has a allowed schema
   function checkURI(attribute, uri, options) {
     options = options | {};
-    options.filteredTags = options.filteredTags | ['href', 'src'];
+    options.urlAttributes = options.urlAttributes | ['href', 'src'];
     options.allowedSchemas = options.allowedSchemas | ['http', 'https', 'ftp', 'mailto'];
-    if(urlAttributes.indexOf(attribute) != -1) {
+    if(options.urlAttributes.indexOf(attribute) != -1) {
     	 var schemaRegEx = /^\s*([A-Za-z][A-Za-z0-9\+\-\.]*):(.*)$/;
     	 if(schemaRegEx.exec(uri)!=null) {
-    	   if(allowedSchemas.indexOf(RegExp.$1) == -1) {
+    	   if(options.allowedSchemas.indexOf(RegExp.$1) == -1) {
         	return null;
     	   }
     	 }


### PR DESCRIPTION
This fix filter out  link and image URIs like javascript:alert(); that are used for XSS. 
It uses whitelisting and only allows http(s) and ftp URIs. 
