### PR TITLE
Conversion of documentation to yuidoc.

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -371,7 +371,8 @@ markdown.pl as closely as possible. Well actually we follow the behaviour of
 that script which in some places is not exactly what the syntax web page
 says.
 
-@property dialects.Gruber
+@property Markdown.dialects.Gruber
+@type Object
 **/
 Markdown.dialects.Gruber = {
   block: {
@@ -1188,7 +1189,8 @@ Markdown.buildInlinePatterns( Markdown.dialects.Gruber.inline );
 
 Alternative using the [Maruku](http://maruku.rubyforge.org/) dialect of Markdown.
 
-@property dialects.Maruku
+@property Markdown.dialects.Maruku
+@type Object
 **/
 Markdown.dialects.Maruku = Markdown.subclassDialect( Markdown.dialects.Gruber );
 


### PR DESCRIPTION
As discussed with Ash, I've migrated and edited some of the documentation to be compatible with yuidoc (http://yui.github.com/yuidoc/syntax/index.html), which supports full markdown and more programmatic documentation.

You can see the generated documentation here:
http://j.shirley.im/tech/yui/gallery-markdown/docs/classes/Markdown.html

(It's all node-based, very easy to setup).

Thanks!
