### PR TITLE
Declared 'res' var locally so it isn't global

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1091,7 +1091,7 @@ Markdown.DialectHelpers.inline_until_char = function( text, want ) {
       return null;
     }
 
-    res = this.dialect.inline.__oneElement__.call(this, text.substr( consumed ) );
+    var res = this.dialect.inline.__oneElement__.call(this, text.substr( consumed ) );
     consumed += res[ 0 ];
     // Add any returned nodes.
     nodes.push.apply( nodes, res.slice( 1 ) );


### PR DESCRIPTION
Please merge me, it's a quick 1 line fix, prevents 'res' var from getting hoisted into global scope and causing conflicts in my project, thanks :)
