### PR TITLE
Fix for issue #58 "Windows linebreak issues"

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -160,6 +160,7 @@ function count_lines( str ) {
 
 // Internal - split source into rough blocks
 Markdown.prototype.split_blocks = function splitBlocks( input, startLine ) {
+  input = input.replace(/(\r\n|\n|\r)/g, '\n');
   // [\s\S] matches _anything_ (newline or space)
   var re = /([\s\S]+?)($|\n(?:\s*\n|$)+)/g,
       blocks = [],


### PR DESCRIPTION
Fix for issue #58 "Windows linebreak issues"

I installed markdown 0.4.0 through npm. While using md2html from the commandline on windows, I noticed that the program chokes on end of line marks that windows uses `\r\n`. I also noticed this same problem when using JSDoc3 which, has incorporated markdown-js into its source. 

This pull request fixes the issue by replacing line breaks of the form `\r\n`, `\n`, and `\r` with the line break `\n`. I followed the process to the `split_blocks` function and inserted the filter on input text to occur just before it is processed. I believe this is the point in code that all input text has to pass through and that by affecting things here I've resolved the issue for all cases without introducing any bugs. Of course I could be wrong.

I commit these Glorious updates to make stuff do things, better!
