### PR TITLE
Make markdown.js work with IE8

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -32,7 +32,7 @@
  *
  *  [JsonML]: http://jsonml.org/ "JSON Markup Language"
  **/
-var Markdown = expose.Markdown = function Markdown(dialect) {
+var Markdown = expose.Markdown = function(dialect) {
   switch (typeof dialect) {
     case "undefined":
       this.dialect = Markdown.dialects.Gruber;
@@ -495,11 +495,11 @@ Markdown.dialects.Gruber = {
         if (i+1 == stack.length) {
           // Last stack frame
           // Keep the same array, but replace the contents
-          last_li.push( ["para"].concat( last_li.splice(1) ) );
+          last_li.push( ["para"].concat( last_li.splice(1, last_li.length - 1) ) );
         }
         else {
           var sublist = last_li.pop();
-          last_li.push( ["para"].concat( last_li.splice(1) ), sublist );
+          last_li.push( ["para"].concat( last_li.splice(1, last_li.length - 1) ), sublist );
         }
       }
 
@@ -576,7 +576,7 @@ Markdown.dialects.Gruber = {
                 for (i = 0; i < stack.length; i++) {
                   if ( stack[ i ].indent != m[1] ) continue;
                   list = stack[ i ].list;
-                  stack.splice( i+1 );
+                  stack.splice( i+1, stack.length - (i+1) );
                   found = true;
                   break;
                 }
@@ -585,7 +585,7 @@ Markdown.dialects.Gruber = {
                   //print("not found. l:", uneval(l));
                   wanted_depth++;
                   if (wanted_depth <= stack.length) {
-                    stack.splice(wanted_depth);
+                    stack.splice(wanted_depth, stack.length - wanted_depth);
                     //print("Desired depth now", wanted_depth, "stack:", stack.length);
                     list = stack[wanted_depth-1].list;
                     //print("list:", uneval(list) );
@@ -1492,7 +1492,7 @@ function convert_tree_to_html( tree, references, options ) {
       jsonml[ 0 ] = "pre";
       i = attrs ? 2 : 1;
       var code = [ "code" ];
-      code.push.apply( code, jsonml.splice( i ) );
+      code.push.apply( code, jsonml.splice( i, jsonml.length - i ) );
       jsonml[ i ] = code;
       break;
     case "inlinecode":


### PR DESCRIPTION
IE8's Array.prototype.splice requires 2nd argument to specify the
number of elements to be removed. Without that, nothing is removed.

If JS compressor (e.g., yui) compresses markdown.js,

  ... function Markdown(dialect) {

will become something like:

  ... function g(d) { ...

Then, Markdown.dialects.Gruber becomes g.dialects.Gruber.
But IE8 does not understand this. The fix is just remove
"Markdown" from after "function".
