### PR TITLE
pre code platform Compatible

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1492,7 +1492,7 @@ function convert_tree_to_html( tree, references, options ) {
       jsonml[ 0 ] = "pre";
       i = attrs ? 2 : 1;
       var code = [ "code" ];
-      code.push.apply( code, jsonml.splice( i ) );
+      code.push.apply( code, jsonml.splice( i , 1 ) );
       jsonml[ i ] = code;
       break;
     case "inlinecode":


### PR DESCRIPTION
Low-end engine browers Array.prototype.splice requires 2nd argument to specify the
number of elements to be removed.

jsonml.splice(i, 1);

you can't remove the '1'.
- ```
   code.push.apply( code, jsonml.splice( i ) );
  ```
- ```
   code.push.apply( code, jsonml.splice( i , 1 ) );
  ```
