### PR TITLE
IE9 doesn't support addressing characters as array indices

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -817,7 +817,7 @@ Markdown.dialects.Gruber.inline = {
       // [ length of input processed, node/children to add... ]
       // Only esacape: \ ` * _ { } [ ] ( ) # * + - . !
       if ( text.match( /^\\[\\`\*_{}\[\]()#\+.!\-]/ ) )
-        return [ 2, text[1] ];
+        return [ 2, text.charAt( 1 ) ];
       else
         // Not an esacpe
         return [ 1, "\\" ];
@@ -1096,7 +1096,7 @@ Markdown.DialectHelpers.inline_until_char = function( text, want ) {
       nodes = [];
 
   while ( true ) {
-    if ( text[ consumed ] == want ) {
+    if ( text.charAt( consumed ) == want ) {
       // Found the character we were looking for
       consumed++;
       return [ consumed, nodes ];


### PR DESCRIPTION
I don't know about other versions, but my version of IE9 doesn't support string characters using array indices.

Replaced "text[...]" with "text.charAt(...)" which fixed the issue for me.
