### PR TITLE
Disabled global HTML escaping, while always escaping within code blocks.

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1434,10 +1434,14 @@ function escapeHTML( text ) {
              .replace( /'/g, "&#39;" );
 }
 
-function render_tree( jsonml ) {
+function render_tree( jsonml, options ) {
+  options = options || {};
+  // escape HTML in strings?
+  options.escape = options.escape || false;
+
   // basic case
   if ( typeof jsonml === "string" ) {
-    return escapeHTML( jsonml );
+    return options.escape ? escapeHTML( jsonml ) : jsonml;
   }
 
   var tag = jsonml.shift(),
@@ -1449,7 +1453,7 @@ function render_tree( jsonml ) {
   }
 
   while ( jsonml.length ) {
-    content.push( render_tree( jsonml.shift() ) );
+    content.push( render_tree( jsonml.shift(), {escape: tag == 'code'} ) );
   }
 
   var tag_attrs = "";

--- a/test/interface.t.js
+++ b/test/interface.t.js
@@ -23,3 +23,16 @@ test("arguments untouched", function(t) {
 
   t.end();
 });
+
+test("code escaped", function(t){
+  var input = "Here is an <i>example</i> of HTML:\n\n    <p>Paragraph</p>",
+      tree = markdown.parse( input ),
+      output = markdown.toHTML( tree ),
+      expected = "<p>Here is an <i>example</i> of HTML:</p>\n\n<pre><code>&lt;p&gt;Paragraph&lt;/p&gt;</code></pre>";
+
+  // Escaping is done at the toHTML stage, so we test our escaping here,
+  // and not in features.
+  t.equivalent( expected, output, "HTML inside code blocks is escaped" );
+
+  t.end();
+});


### PR DESCRIPTION
This follows from https://github.com/evilstreak/markdown-js/pull/34, opting to disable HTML escaping except in code blocks. I understand that it's been stated to be undesirable by the maintainers, but I think it is a more consistent implementation of Markdown.

I've added a test that mimics the handling here http://babelmark.bobtfish.net/?markdown=%3Cp%3EHTML%3C%2Fp%3E%0D%0A%0D%0A++++%3Cp%3ECode%3C%2Fp%3E&src=1&dest=2
