### PR TITLE
Fix: never render <null> or <undefined> html tags

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1452,6 +1452,11 @@ function render_tree( jsonml ) {
     content.push( render_tree( jsonml.shift() ) );
   }
 
+  // edge case where tag has been removed at some point (e.g. preprocessTreeNode)
+  if ( !tag ) {
+    return content
+  }
+
   var tag_attrs = "";
   for ( var a in attributes ) {
     tag_attrs += " " + a + '="' + escapeHTML( attributes[ a ] ) + '"';


### PR DESCRIPTION
If a preprocessor needs to remove a tag, this patch allows it to do so by making the tag null or undefined.
