### PR TITLE
Fixed critical error in IE8

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -163,8 +163,8 @@ function count_lines( str ) {
 // Internal - split source into rough blocks
 Markdown.prototype.split_blocks = function splitBlocks( input, startLine ) {
   input = input.replace(/(\r\n|\n|\r)/g, "\n");
-  // [^] matches _anything_ (newline or space)
-  var re = /([^]+?)($|\n#|\n(?:\s*\n|$)+)/g,
+  // [\s\S] matches _anything_ (newline or space)
+  var re = /([\s\S]+?)($|\n#|\n(?:\s*\n|$)+)/g,
       blocks = [],
       m;
 


### PR DESCRIPTION
`[^]` in regular expression causes "Expected ']' in regular expression" error at least in IE8 (other versions are untested). Just replaced `[^]` by `[\s\S]`.
