### PR TITLE
Bump up minimum node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "lint": "grunt jshint"
   },
   "engines": {
-    "node": ">=0.6.0"
+    "node": ">=0.8.0"
   }
 }


### PR DESCRIPTION
When we introduced grunt we had to remove support for node 0.6 from Travis. This PR brings our `engines` section of package.json in sync with the builds currently occurring on travis.
