### PR TITLE
Support for escaping `>`

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -529,7 +529,7 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
       "]": function () {},
       "}": function () {},
 
-      __escape__ : /^\\[\\`\*_{}\[\]()#\+.!\-]/,
+      __escape__ : /^\\[\\`\*_{}<>\[\]()#\+.!\-]/,
 
       "\\": function escaped( text ) {
         // [ length of input processed, node/children to add... ]

--- a/test/regressions.t.js
+++ b/test/regressions.t.js
@@ -428,6 +428,7 @@ test( "inline_br", function(t, md) {
 
 test( "inline_escape", function(t, md) {
   t.equivalent( md.processInline("\\bar"), [ "\\bar" ], "invalid escape" );
+  t.equivalent( md.processInline("\\>"), [ ">" ], "escapes >" );
   t.equivalent( md.processInline("\\*foo*"), [ "*foo*" ], "escaped em" );
 });
 


### PR DESCRIPTION
I am trying to support as much of MDTest 1.1 as possible. They include a test for escaping `>` symbols:

https://github.com/michelf/mdtest/blob/master/Markdown.mdtest/Backslash%20escapes.text

This patch adds support for escaping the symbol and helps to pass that test.
