### PR TITLE
In image tags, put the `src` attribute first.

### DIFF
--- a/src/render_tree.js
+++ b/src/render_tree.js
@@ -111,6 +111,11 @@ define(['./core', './markdown_helpers'], function(Markdown, MarkdownHelpers) {
       content.push( render_tree( jsonml.shift() ) );
 
     var tag_attrs = "";
+    if (typeof attributes.src !== 'undefined') {
+      tag_attrs += ' src="' + escapeHTML( attributes.src ) + '"';
+      delete attributes.src;
+    }
+
     for ( var a in attributes )
       tag_attrs += " " + a + '="' + escapeHTML( attributes[ a ] ) + '"';
 

--- a/test/features.t.js
+++ b/test/features.t.js
@@ -1,4 +1,5 @@
-var markdown = require("../src/markdown");
+var markdown = require("../src/markdown"),
+    tap = require("tap");
 
 function test_dialect( dialect, features ) {
   var fs = require("fs"),
@@ -80,3 +81,10 @@ dialects.Maruku.push( "meta", "definition_lists", "tables" );
 for ( var d in dialects ) {
   test_dialect( d, dialects[ d ] );
 }
+
+
+tap.test("src attribute order", function(t) {
+  var tree = markdown.toHTML("![photo](/images/photo.jpg)");
+  t.equivalent( tree, '<p><img src="/images/photo.jpg" alt="photo"/></p>' );
+  t.end();
+});

--- a/test/html_renderer.t.js
+++ b/test/html_renderer.t.js
@@ -1,0 +1,8 @@
+var markdown = require("../src/markdown"),
+    tap = require("tap");
+
+tap.test("src attribute order", function(t) {
+  var tree = markdown.toHTML("![photo](/images/photo.jpg)");
+  t.equivalent( tree, '<p><img src="/images/photo.jpg" alt="photo"/></p>' );
+  t.end();
+});


### PR DESCRIPTION
This one might be more controversial, so I'm happy to discuss it.

MDTest1.1 wants all `src` attributes to be first. This is obviously not possible in the JsonML representation because Javascript objects have no order to their key/values. However, we can easily check if a src attribute is present and output it first in the rendering phase.

At first I thought this was silly and not worth doing, but after speaking to my team I realized that if we want HTML that reads nicely, the `src` attribute of an image should be first. You can debate secondary attributes, but for good looking HTML, the src is the most important and should be read first.
