### PR TITLE
Support Markdown links with multiple spaces in front

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -603,7 +603,7 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
         // The parens have to be balanced
         var m = text.match( /^\s*\([ \t]*([^"']*)(?:[ \t]+(["'])(.*?)\2)?[ \t]*\)/ );
         if ( m ) {
-          var url = m[1];
+          var url = m[1].replace(/\s+$/, '');
           consumed += m[0].length;
 
           if ( url && url[0] === "<" && url[url.length-1] === ">" )

--- a/test/regressions.t.js
+++ b/test/regressions.t.js
@@ -487,6 +487,14 @@ test( "inline_link", function(t, md) {
                                   [ [ "link", { href: "url", title: "title" }, "text" ] ],
                                   "inline link II" );
 
+  t.equivalent( md.processInline( "[text](url  'title')" ),
+                                  [ [ "link", { href: "url", title: "title" }, "text" ] ],
+                                  "inline link II" );
+
+  t.equivalent( md.processInline( "[text](url\t\t'title')" ),
+                                  [ [ "link", { href: "url", title: "title" }, "text" ] ],
+                                  "inline link II" );
+
   t.equivalent( md.processInline( "[text](url 'tit'le') after')" ),
                                   [ [ "link", { href: "url", title: "tit'le" }, "text" ], " after')" ],
                                   "inline link III" );


### PR DESCRIPTION
Current markdown-js was failing if you attempted to format:

`[URL and title](/url/  "title preceded by two spaces").`

In this case, it would put the second space in the url section:

`<p><a href="url " title="title">text</a></p>`

This patch ensures that the URL has no trailing spaces.
