### PR TITLE
FIX: Support for IMG URLs with parentheses in them.

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -548,7 +548,11 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
 
         // ![Alt text](/path/to/img.jpg "Optional title")
         //      1          2            3       4         <--- captures
-        var m = text.match( /^!\[(.*?)\][ \t]*\([ \t]*([^")]*?)(?:[ \t]+(["'])(.*?)\3)?[ \t]*\)/ );
+        //
+        // First attempt to use a strong URL regexp to catch things like parentheses. If it misses, use the
+        // old one.
+        var m = text.match( /^!\[(.*?)][ \t]*\(((?:https?:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.])(?:[^\s()<>]+|\([^\s()<>]+\))+(?:\([^\s()<>]+\)|[^`!()\[\]{};:'".,<>?«»“”‘’\s]))\)([ \t])*(["'].*["'])?/ ) ||
+                text.match( /^!\[(.*?)\][ \t]*\([ \t]*([^")]*?)(?:[ \t]+(["'])(.*?)\3)?[ \t]*\)/ );
 
         if ( m ) {
           if ( m[2] && m[2][0] === "<" && m[2][m[2].length-1] === ">" )

--- a/test/regressions.t.js
+++ b/test/regressions.t.js
@@ -476,6 +476,10 @@ test( "inline_img", function(t, md) {
   t.equivalent( md.processInline( "![alt] [id]" ),
                                   [ [ "img_ref", { ref: "id", alt: "alt", original: "![alt] [id]" } ] ],
                                   "ref img II" );
+
+  t.equivalent( md.processInline( "![contains parens](http://example.com/(parens).jpg)" ),
+                                  [ ["img", { href: "http://example.com/(parens).jpg", alt: "contains parens"} ] ],
+                                  "images with parentheses in the URL" );
 });
 
 test( "inline_link", function(t, md) {


### PR DESCRIPTION
Currently markdown-js doesn't support image URLs with parentheses in them. Having parentheses in URLs is valid and some sites like Wikipedia use them often.

This fix will first attempt to use a strong regexp to match URLs more accurately including parentheses. If it fails, it will revert to the old regex which is more permissive. 

There's a new test for a funky URL which now passes (and all previous tests pass too.)
