### PR TITLE
Support references that span lines

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -661,7 +661,8 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
         // Only if id is plain (no formatting.)
         if ( children.length === 1 && typeof children[0] === "string" ) {
 
-          attrs = { ref: children[0].toLowerCase(),  original: orig.substr( 0, consumed ) };
+          var normalized = children[0].toLowerCase().replace(/\s+/, ' ');
+          attrs = { ref: normalized,  original: orig.substr( 0, consumed ) };
           link = [ "link_ref", attrs, children[0] ];
           return [ consumed, link ];
         }

--- a/test/features/links/reference_with_newline.json
+++ b/test/features/links/reference_with_newline.json
@@ -1,0 +1,10 @@
+["html",
+  ["p",
+    "This one has a ",
+    ["a",
+      { "href" : "/foo" },
+      "line\nbreak"
+    ],
+    "."
+  ]
+]

--- a/test/features/links/reference_with_newline.text
+++ b/test/features/links/reference_with_newline.text
@@ -1,0 +1,4 @@
+This one has a [line
+break].
+
+[line break]: /foo

--- a/test/features/links/reference_with_newline_and_space.json
+++ b/test/features/links/reference_with_newline_and_space.json
@@ -1,0 +1,10 @@
+["html",
+  ["p",
+    "This one has a ",
+    ["a",
+      { "href" : "/foo" },
+      "line \nbreak"
+    ],
+    "."
+  ]
+]

--- a/test/features/links/reference_with_newline_and_space.text
+++ b/test/features/links/reference_with_newline_and_space.text
@@ -1,0 +1,4 @@
+This one has a [line 
+break].
+
+[line break]: /foo


### PR DESCRIPTION
Markdown-js doesn't handle references that span multiple lines. For example:

```
I am a [link
that] spans lines.

[link that]: /some-link
```

Most of the code to support this is already in place. It was just an issue of normalizing the reference matcher to ignore new lines.
