### PR TITLE
FIX: Allow link references following a list

### DIFF
--- a/test/features/lists/references.json
+++ b/test/features/lists/references.json
@@ -1,0 +1,7 @@
+["html",
+  ["ul",
+    ["li",
+      ["a", {"href": "http://eviltrout.com"}, "Evil Trout"]
+    ]
+  ]
+]

--- a/test/features/lists/references.text
+++ b/test/features/lists/references.text
@@ -1,0 +1,2 @@
+* [Evil Trout][1]
+  [1]: http://eviltrout.com


### PR DESCRIPTION
This is an issue that was reported via Discourse. If you follow a list with a link reference, it would not parse the link correctly. 

This patch includes a test and fix for this failing case. It also extracts `create_references` and `extract_attr` as functions for re-use in the fix.
