### PR TITLE
FIX: Allow reference definitions with quotes

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -428,7 +428,7 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
       },
 
       referenceDefn: function referenceDefn( block, next) {
-        var re = /^\s*\[(.*?)\]:\s*(\S+)(?:\s+(?:(['"])(.*?)\3|\((.*?)\)))?\n?/;
+        var re = /^\s*\[(.*?)\]:\s*(\S+)(?:\s+(?:(['"])(.*)\3|\((.*?)\)))?\n?/;
         // interesting matches are [ , ref_id, url, , title, title ]
 
         if ( !block.match(re) )

--- a/test/features/links/reference_with_quote.json
+++ b/test/features/links/reference_with_quote.json
@@ -1,0 +1,5 @@
+["html",
+  ["p",
+     "Foo ", [ "a", {"href": "/url/", "title": "Title with \"quotes\" inside"}, "bar" ], "."
+  ]
+]

--- a/test/features/links/reference_with_quote.text
+++ b/test/features/links/reference_with_quote.text
@@ -1,0 +1,3 @@
+Foo [bar][].
+
+  [bar]: /url/ "Title with "quotes" inside"


### PR DESCRIPTION
This patch allows reference definitions with quotes inside them. I think the test illustrates what it supports :)
