### PR TITLE
FIX: Paragraphs in nested lists

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -208,6 +208,7 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
 
           if ( last_li[1] instanceof Array && last_li[1][0] === "para" )
             return;
+
           if ( i + 1 === stack.length ) {
             // Last stack frame
             // Keep the same array, but replace the contents
@@ -367,8 +368,10 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
                 break;
               }
 
-              // Make sure all listitems up the stack are paragraphs
-              forEach( stack, paragraphify, this);
+              // Add paragraphs if the indentation level stays the same
+              if (stack[stack.length-1].indent === block.match(/^\s*/)[0]) {
+                forEach( stack, paragraphify, this);
+              }
 
               loose = true;
               continue loose_search;

--- a/test/features/lists/nested_para.json
+++ b/test/features/lists/nested_para.json
@@ -1,0 +1,14 @@
+["html",
+  ["ol",
+    ["li", ["p", "First"] ],
+    ["li",
+    	["p", "Second:"],
+    	["ul",
+    		["li", "Fee"],
+    		["li", "Fie"],
+    		["li", "Foe"]
+    	]
+    ],
+    ["li", ["p", "Third"]]
+  ]
+]

--- a/test/features/lists/nested_para.text
+++ b/test/features/lists/nested_para.text
@@ -1,0 +1,9 @@
+1. First
+
+2. Second:
+	* Fee
+	* Fie
+	* Foe
+
+3. Third
+


### PR DESCRIPTION
There is an issue where an extra paragraph would be added to the last item of nested lists. This fix only applies paragraphs to new blocks in lists when the indentation level stays the same.
