### PR TITLE
FIX: HTML blocks should not be surrounded by `<p>`

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -465,6 +465,12 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
       },
 
       para: function para( block ) {
+
+        // If the block starts with a HTML tag, don't wrap it in a para
+        if (block.match(/^<[^>]+\>/)) {
+          return this.processInline(block);
+        }
+
         // everything's a para!
         return [ ["para"].concat( this.processInline( block ) ) ];
       }

--- a/src/parser.js
+++ b/src/parser.js
@@ -88,10 +88,11 @@ define(['./markdown_helpers', './core'], function(MarkdownHelpers, Markdown) {
       //D:this.debug( "Testing", ord[i] );
       var res = cbs[ ord[i] ].call( this, block, next );
       if ( res ) {
-        //D:this.debug("  matched");
-        if ( !isArray(res) || ( res.length > 0 && !( isArray(res[0]) ) ) )
-          this.debug(ord[i], "didn't return a proper array");
-        //D:this.debug( "" );
+
+        if ( !isArray(res) || ( res.length > 0 && !( isArray(res[0]) ) && ( typeof res[0] !== "string")) ) {
+          this.debug(ord[i], "didn't return proper JsonML");
+        }
+
         return res;
       }
     }

--- a/test/features/linebreaks/html.json
+++ b/test/features/linebreaks/html.json
@@ -1,0 +1,4 @@
+["html",
+  ["p", "This is a paragraph."],
+  "<b>This is not in a paragraph</b>"
+]

--- a/test/features/linebreaks/html.text
+++ b/test/features/linebreaks/html.text
@@ -1,0 +1,3 @@
+This is a paragraph.
+
+<b>This is not in a paragraph</b>


### PR DESCRIPTION
Part of the Markdown spec specifies that if html tags are present in their own block they should not be surrounded by paragraphs. This patch checks to see if a block begins with an HTML tag before surrounding it in a paragraph.

A secondary part changes the debugging method to not complain if the JsonML fragment that comes back is a string. I suppose previously everything had a tag around it!
