### PR TITLE
A block helper can return a string. It needn't be logged as a problem.

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -88,10 +88,11 @@ define(['./markdown_helpers', './core'], function(MarkdownHelpers, Markdown) {
       //D:this.debug( "Testing", ord[i] );
       var res = cbs[ ord[i] ].call( this, block, next );
       if ( res ) {
-        //D:this.debug("  matched");
-        if ( !isArray(res) || ( res.length > 0 && !( isArray(res[0]) ) ) )
-          this.debug(ord[i], "didn't return a proper array");
-        //D:this.debug( "" );
+
+        if ( !isArray(res) || ( res.length > 0 && !( isArray(res[0]) ) && ( typeof res[0] !== "string")) ) {
+          this.debug(ord[i], "didn't return proper JsonML");
+        }
+
         return res;
       }
     }


### PR DESCRIPTION
My previous pull request to not surround HTML with paragraphs was not accepted. It contained this other fix which I think is still worth having on its own: JsonML supports strings of text, not just tags. 

This patch changes the warning message to not complain when the text is a string either.
