### PR TITLE
Replace `count_lines` with faster implementation

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -19,12 +19,14 @@ define(['./markdown_helpers', './core'], function(MarkdownHelpers, Markdown) {
     return md.toTree( source );
   };
 
+  /**
+   *  count_lines( str ) -> count
+   *  - str (String): String whose lines we want to count
+   *
+   *  Counts the number of linebreaks in `str`
+   **/
   function count_lines( str ) {
-    var n = 0,
-        i = -1;
-    while ( ( i = str.indexOf("\n", i + 1) ) !== -1 )
-      n++;
-    return n;
+    return str.split("\n").length - 1;
   }
 
   // Internal - split source into rough blocks


### PR DESCRIPTION
This patch replaces `count_lines` with a faster implementation.

```
current method:

console.time('count_lines'); for (i=0; i<100000; i++) { count_lines(longString) }; console.timeEnd('count_lines')
count_lines: 221.655ms

new version:

console.time('count_lines'); for (i=0; i<100000; i++) { count_lines(longString) }; console.timeEnd('count_lines')
count_lines: 114.764ms
```
