### PR TITLE
Bugfix, call horizRule with proper context

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -361,7 +361,7 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
               block = next.shift();
 
               // Check for an HR following a list: features/lists/hr_abutting
-              var hr = this.dialect.block.horizRule( block, next );
+              var hr = this.dialect.block.horizRule( this, block, next);
 
               if ( hr ) {
                 ret.push.apply(ret, hr);


### PR DESCRIPTION
It was a bug, when gruber dialect call 'lists' method and 'lists' call horizRule but with wrong context. Thus I had an error in browser. Here are its text and stack:

Uncaught TypeError: Object #<Object> has no method 'processBlock' markdown.js:398
horizRule markdown.js:398
Markdown.dialects.Gruber.block.lists markdown.js:651
processBlock markdown.js:226
toTree markdown.js:261
expose.parse markdown.js:72
toHTMLTree markdown.js:103
toHTML
