### PR TITLE
Allow dollar($) and caret(^) for inline patterns

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -180,7 +180,7 @@ define(['./markdown_helpers', './core'], function(MarkdownHelpers, Markdown) {
       // __foo__ is reserved and not a pattern
       if ( i.match( /^__.*__$/) )
         continue;
-      var l = i.replace( /([\\.*+?|()\[\]{}])/g, "\\$1" )
+      var l = i.replace( /([\\.*+?^$|()\[\]{}])/g, "\\$1" )
                .replace( /\n/, "\\n" );
       patterns.push( i.length === 1 ? l : "(?:" + l + ")" );
     }


### PR DESCRIPTION
This makes sure that it is possible to use all ascii symbols for inline patterns including the dollar ($) and caret (^) symbol. Especially dollar is usefull, as (La)TeX uses dollar ($) for math sections. With this change, someone could easily extend markdown so that recognizes LaTeX math sections (for mathax support).
