### PR TITLE
Expose `DialectHelpers` so people can include markdown-js and then add their own dialects

### DIFF
--- a/inc/footer-node.js
+++ b/inc/footer-node.js
@@ -4,5 +4,6 @@
   expose.toHTML = Markdown.toHTML;
   expose.toHTMLTree = Markdown.toHTMLTree;
   expose.renderJsonML = Markdown.renderJsonML;
+  expose.DialectHelpers = DialectHelpers;
 
 })(exports);

--- a/inc/footer-web.js
+++ b/inc/footer-web.js
@@ -4,6 +4,7 @@
   expose.toHTML = Markdown.toHTML;
   expose.toHTMLTree = Markdown.toHTMLTree;
   expose.renderJsonML = Markdown.renderJsonML;
+  expose.DialectHelpers = DialectHelpers;
 
 })(function() {
   window.markdown = {};


### PR DESCRIPTION
This exposes the `DialectHelpers` from the IIFE so that users can create their own Dialects. Discourse does this to extend things after including markdown-js and it's very useful!
