### PR TITLE
FIX: On v8, a regular expression was crashing

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -541,6 +541,9 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
 
       "![": function image( text ) {
 
+        // Without this guard V8 crashes hard on the RegExp
+        if (text.indexOf('(') >= 0 && text.indexOf(')') === -1) { return; }
+
         // Unlike images, alt text is plain text only. no other elements are
         // allowed in there
 

--- a/test/features/images/incomplete_image.json
+++ b/test/features/images/incomplete_image.json
@@ -1,0 +1,4 @@
+[ "html",
+  [ "p",
+    "![alert](http://cdn.eviltrout.com/images/trout.png" ] ]
+

--- a/test/features/images/incomplete_image.text
+++ b/test/features/images/incomplete_image.text
@@ -1,0 +1,2 @@
+![alert](http://cdn.eviltrout.com/images/trout.png
+


### PR DESCRIPTION
On v8, a regular expression was crashing if an image had no ending
parens. Interestingly enough, this doesn't happen in other browsers so
it seems to be v8 specific. This patch prevents it from happening and
adds a test.
