### PR TITLE
FIX: Handle URLs with apostrophes in them.

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -8,6 +8,9 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
       isEmpty = MarkdownHelpers.isEmpty,
       inline_until_char = DialectHelpers.inline_until_char;
 
+  // A robust regexp for matching URLs. Thakns: https://gist.github.com/dperini/729294
+  var urlRegexp = /(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?/i.source;
+
   /**
    * Gruber dialect
    *
@@ -552,7 +555,7 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
         //
         // First attempt to use a strong URL regexp to catch things like parentheses. If it misses, use the
         // old one.
-        var m = text.match( /^!\[(.*?)][ \t]*\(((?:https?:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.])(?:[^\s()<>]+|\([^\s()<>]+\))+(?:\([^\s()<>]+\)|[^`!()\[\]{};:'".,<>?«»“”‘’\s]))\)([ \t])*(["'].*["'])?/ ) ||
+        var m = text.match(new RegExp("^!\\[(.*?)][ \\t]*\\((" + urlRegexp + ")\\)([ \\t])*([\"'].*[\"'])?")) ||
                 text.match( /^!\[(.*?)\][ \t]*\([ \t]*([^")]*?)(?:[ \t]+(["'])(.*?)\3)?[ \t]*\)/ );
 
         if ( m ) {
@@ -654,10 +657,16 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
           return [ consumed, link ];
         }
 
+        m = text.match(new RegExp("^\\((" + urlRegexp + ")\\)"));
+        if (m && m[1]) {
+          consumed += m[0].length;
+          link = ["link", {href: m[1]}].concat(children);
+          return [consumed, link];
+        }
+
         // [Alt text][id]
         // [Alt text] [id]
         m = text.match( /^\s*\[(.*?)\]/ );
-
         if ( m ) {
 
           consumed += m[ 0 ].length;

--- a/test/features/links/apostrophe.json
+++ b/test/features/links/apostrophe.json
@@ -1,0 +1,8 @@
+["html",
+  ["p",
+    ["a",
+      { "href" : "http://wiki.postgresql.org/wiki/What's_new_in_PostgreSQL_9.3" },
+      "Postgres 9.3"
+    ]
+  ]
+]

--- a/test/features/links/apostrophe.text
+++ b/test/features/links/apostrophe.text
@@ -1,0 +1,1 @@
+[Postgres 9.3](http://wiki.postgresql.org/wiki/What's_new_in_PostgreSQL_9.3)


### PR DESCRIPTION
This fix supports simple links to URLs with apostrophes in them. 
