### PR TITLE
FIX: Support for quotes inside lists

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -331,7 +331,13 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
             } // tight_search
 
             if ( li_accumulate.length ) {
-              add( last_li, loose, this.processInline( li_accumulate ), nl );
+              
+              var contents = this.processBlock(li_accumulate, []),
+                  firstBlock = contents[0];
+
+              firstBlock.shift();
+              contents.splice.apply(contents, [0, 1].concat(firstBlock));
+              add( last_li, loose, contents, nl );
 
               // Let's not creating a trailing \n after content in the li
               if(last_li[last_li.length-1] === "\n") {

--- a/test/features/lists/quote_inside.json
+++ b/test/features/lists/quote_inside.json
@@ -1,0 +1,9 @@
+["html",
+  ["ol",
+    [ "li",
+      "bar",
+      ["blockquote", ["p", "this should go under #1"]]
+    ]
+  ]
+]
+

--- a/test/features/lists/quote_inside.text
+++ b/test/features/lists/quote_inside.text
@@ -1,0 +1,2 @@
+1. bar
+  > this should go under #1


### PR DESCRIPTION
It turns out that `processInline` doesn't  work for a list's content as
it can have blocks such as quotes inside them. This code processes the
content of lists as a block, but removes the first paragraph to keep
with the markdown spec.
