### PR TITLE
Add bower.json for grunt-bower-install compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+    "name": "markdown",
+    "homepage": "https://github.com/evilstreak/markdown-js",
+    "_source": "git://github.com/evilstreak/markdown-js.git",
+    "_target": "master",
+    "_originalSource": "markdown",
+    "version": "v0.6.0-beta1",
+    "authors": [
+        "Dominic Baggott <dominic.baggott@gmail.com> (http://evilstreak.co.uk)",
+        "Ash Berlin <ash_markdownjs@firemirror.com> (http://ashberlin.com)"
+    ],
+    "description": "A sensible Markdown parser for javascript",
+    "main": "./lib/index.js",
+    "keywords": [
+        "markdown",
+        "text processing",
+        "ast"
+    ],
+    "license": "MIT"
+}


### PR DESCRIPTION
Though markdown is already a registered bower package, without a bower.json file it is not compatible with [grunt-bower-install](https://github.com/stephenplusplus/grunt-bower-install). Please keep in mind that the version in bower.json will need to be bumped for new releases.
