### PR TITLE
FIX: Uncaught TypeError: Cannot call method 'shift' of undefined

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -334,22 +334,24 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
             } // tight_search
 
             if ( li_accumulate.length ) {
-              
+
               var contents = this.processBlock(li_accumulate, []),
                   firstBlock = contents[0];
 
-              firstBlock.shift();
-              contents.splice.apply(contents, [0, 1].concat(firstBlock));
-              add( last_li, loose, contents, nl );
+              if (firstBlock) {
+                firstBlock.shift();
+                contents.splice.apply(contents, [0, 1].concat(firstBlock));
+                add( last_li, loose, contents, nl );
 
-              // Let's not creating a trailing \n after content in the li
-              if(last_li[last_li.length-1] === "\n") {
-                last_li.pop();
+                // Let's not creating a trailing \n after content in the li
+                if(last_li[last_li.length-1] === "\n") {
+                  last_li.pop();
+                }
+
+                // Loose mode will have been dealt with. Reset it
+                loose = false;
+                li_accumulate = "";
               }
-
-              // Loose mode will have been dealt with. Reset it
-              loose = false;
-              li_accumulate = "";
             }
 
             // Look at the next block - we might have a loose list. Or an extra

--- a/test/features/links/reference_missing.json
+++ b/test/features/links/reference_missing.json
@@ -1,0 +1,9 @@
+["html",
+  ["p",
+    ["a",
+      { "href" : "http://example.com" },
+      "hi"
+    ]
+  ],
+  ["ul", ["li"]]
+]

--- a/test/features/links/reference_missing.text
+++ b/test/features/links/reference_missing.text
@@ -1,0 +1,3 @@
+[hi][link]
+
+  - [link]: http://example.com


### PR DESCRIPTION
This was discovered in Discourse. The fix is a simple `if` check to see if a variable is defined. Tests provided.

see https://meta.discourse.org/t/js-exception-in-composer-method-shift/14589
