### PR TITLE
Fix of src attribute population.

### DIFF
--- a/src/render_tree.js
+++ b/src/render_tree.js
@@ -184,8 +184,10 @@ define(['./core', './markdown_helpers'], function(Markdown, MarkdownHelpers) {
       jsonml[ 0 ] = "code";
       break;
     case "img":
-      jsonml[ 1 ].src = jsonml[ 1 ].href;
-      delete jsonml[ 1 ].href;
+      if (typeof jsonml[1].src === 'undefined') {
+        jsonml[ 1 ].src = jsonml[ 1 ].href;
+        delete jsonml[ 1 ].href;
+      }
       break;
     case "linebreak":
       jsonml[ 0 ] = "br";


### PR DESCRIPTION
Only fetch the value of href attribute if the src attribute of img tag is undefined.
Otherwise, any customized dialect returning img tag would fail if the processing is done thru toHTML(toHTMLTree(text, dialect)).
