### PR TITLE
FIX: If an attribute was undefined as the result of processing,

### DIFF
--- a/src/render_tree.js
+++ b/src/render_tree.js
@@ -1,4 +1,4 @@
-if (typeof define !== 'function') { var define = require('amdefine')(module) }
+if (typeof define !== 'function') { var define = require('amdefine')(module); }
 
 define(['./core', './markdown_helpers'], function(Markdown, MarkdownHelpers) {
 
@@ -88,11 +88,15 @@ define(['./core', './markdown_helpers'], function(Markdown, MarkdownHelpers) {
 
 
   function escapeHTML( text ) {
-    return text.replace( /&/g, "&amp;" )
-               .replace( /</g, "&lt;" )
-               .replace( />/g, "&gt;" )
-               .replace( /"/g, "&quot;" )
-               .replace( /'/g, "&#39;" );
+    if (text && text.length > 0) {
+      return text.replace( /&/g, "&amp;" )
+                 .replace( /</g, "&lt;" )
+                 .replace( />/g, "&gt;" )
+                 .replace( /"/g, "&quot;" )
+                 .replace( /'/g, "&#39;" );
+    } else {
+      return "";
+    }
   }
 
   function render_tree( jsonml ) {
@@ -116,8 +120,12 @@ define(['./core', './markdown_helpers'], function(Markdown, MarkdownHelpers) {
       delete attributes.src;
     }
 
-    for ( var a in attributes )
-      tag_attrs += " " + a + '="' + escapeHTML( attributes[ a ] ) + '"';
+    for ( var a in attributes ) {
+      var escaped = escapeHTML( attributes[ a ]);
+      if (escaped && escaped.length) {
+        tag_attrs += " " + a + '="' + escaped + '"';
+      }
+    }
 
     // be careful about adding whitespace here for inline elements
     if ( tag === "img" || tag === "br" || tag === "hr" )

--- a/test/render_tree.t.js
+++ b/test/render_tree.t.js
@@ -1,0 +1,14 @@
+var markdown = require("../src/markdown"),
+    tap = require("tap");
+
+tap.test("undefined attribute", function(t) {
+  var tree = markdown.renderJsonML( ['html', ['p', {style: undefined }, 'hello'] ] );
+  t.equivalent( tree, '<p>hello</p>' );
+  t.end();
+});
+
+tap.test("escaped attribute", function(t) {
+  var tree = markdown.renderJsonML( ['html', ['p', {style: "color: blue" }, 'hello'] ] );
+  t.equivalent( tree, '<p style="color: blue">hello</p>' );
+  t.end();
+});


### PR DESCRIPTION
the HTML escaping would raise an error. This adds safety and
prevents that from happening.
