### PR TITLE
FIX: If the `firstBlock` is a string, don't throw an exception

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -6,6 +6,7 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
       extract_attr = MarkdownHelpers.extract_attr,
       mk_block = MarkdownHelpers.mk_block,
       isEmpty = MarkdownHelpers.isEmpty,
+      isArray = MarkdownHelpers.isArray,
       inline_until_char = DialectHelpers.inline_until_char;
 
   // A robust regexp for matching URLs. Thanks: https://gist.github.com/dperini/729294
@@ -339,7 +340,10 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
                   firstBlock = contents[0];
 
               if (firstBlock) {
-                firstBlock.shift();
+
+                // It's possible the first block is a string
+                if (isArray(firstBlock)) { firstBlock.shift(); }
+
                 contents.splice.apply(contents, [0, 1].concat(firstBlock));
                 add( last_li, loose, contents, nl );
 


### PR DESCRIPTION
Sorry I don't have a test for this, because it's specific to something that Discourse adds in via our custom formatting. 

Essentially the issue is `firstBlock` can be a `String` sometimes, and in that case we don't want to shift it, we just want to append it. All grunt tests pass and this fixes the issue in Discourse.

Thanks!
