### PR TITLE
FIX: Error when linking to absolute URLs with absolute links to images

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -9,7 +9,7 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
       inline_until_char = DialectHelpers.inline_until_char;
 
   // A robust regexp for matching URLs. Thanks: https://gist.github.com/dperini/729294
-  var urlRegexp = /(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?/i.source;
+  var urlRegexp = /(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?/i.source;
 
   /**
    * Gruber dialect
@@ -563,8 +563,11 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
         //
         // First attempt to use a strong URL regexp to catch things like parentheses. If it misses, use the
         // old one.
+        var origMatcher = /^!\[(.*?)\][ \t]*\([ \t]*([^")]*?)(?:[ \t]+(["'])(.*?)\3)?[ \t]*\)/;
         var m = text.match(new RegExp("^!\\[(.*?)][ \\t]*\\((" + urlRegexp + ")\\)([ \\t])*([\"'].*[\"'])?")) ||
-                text.match( /^!\[(.*?)\][ \t]*\([ \t]*([^")]*?)(?:[ \t]+(["'])(.*?)\3)?[ \t]*\)/ );
+                text.match(origMatcher);
+
+        if (m && m[2].indexOf(")]") !== -1) { m = text.match(origMatcher); }
 
         if ( m ) {
           if ( m[2] && m[2][0] === "<" && m[2][m[2].length-1] === ">" )

--- a/test/features/images/inside_long_link.json
+++ b/test/features/images/inside_long_link.json
@@ -1,0 +1,11 @@
+["html",
+  ["p",
+    ["a",
+      { "href": "http://company.com/" },
+      ["img", {
+        "alt": "company logo",
+        "src": "http://company.com/images/company-colour.png"
+      } ]
+    ]
+  ]
+]

--- a/test/features/images/inside_long_link.text
+++ b/test/features/images/inside_long_link.text
@@ -1,0 +1,1 @@
+[![company logo](http://company.com/images/company-colour.png)](http://company.com/)


### PR DESCRIPTION
Matching URLs with regular expressions is tough! However, this approach fixes issues when linking to absolute URLs with absolute image URLs inside them.
