### PR TITLE
FIX: edge cases with bbcodes looking like reference definitions and empty links

### DIFF
--- a/src/dialects/gruber.js
+++ b/src/dialects/gruber.js
@@ -457,7 +457,7 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
       },
 
       referenceDefn: function referenceDefn( block, next) {
-        var re = /^\s*\[(.*?)\]:\s*(\S+)(?:\s+(?:(['"])(.*)\3|\((.*?)\)))?\n?/;
+        var re = /^\s*\[([^\[\]]+)\]:\s*(\S+)(?:\s+(?:(['"])(.*)\3|\((.*?)\)))?\n?/;
         // interesting matches are [ , ref_id, url, , title, title ]
 
         if ( !block.match(re) )
@@ -611,6 +611,9 @@ define(['../markdown_helpers', './dialect_helpers', '../parser'], function (Mark
         if ( !res[1] ) {
           return [ res[0] + 1, text.charAt(0) ].concat(res[2]);
         }
+
+        // empty link
+        if ( res[0] === 1 ) { return [ 2, "[]" ]; }
 
         var consumed = 1 + res[ 0 ],
             children = res[ 1 ],

--- a/test/regressions.t.js
+++ b/test/regressions.t.js
@@ -420,6 +420,11 @@ test( "referenceDefn", function(t, md) {
   t.equivalent(md.tree[ 1 ].references, { "id": { href: "example.com" } }, "reference extracted");
   t.equivalent(next, [ mk_block("para") ], "paragraph put back into blocks");
 
+  // Check empty tags and non-tags are ignored
+  md.tree = ["markdown"];
+  t.type(rd.call( md, mk_block("[]: http://example.com"), []), "undefined", "no empty ref name");
+  t.type(rd.call( md, mk_block("[b]label[/b]: description"), []), "undefined", "no brackets in ref name");
+
 });
 
 test( "inline_br", function(t, md) {
@@ -533,6 +538,10 @@ test( "inline_link", function(t, md) {
                                   ],
                                   "ref link II" );
   /* jshint indent: 2 */
+
+  t.equivalent( md.processInline( "[]: text" ),
+                                  [ "[]: text" ],
+                                  "no empty links" );
 });
 
 test( "inline_autolink", function(t, md) {


### PR DESCRIPTION
This fixes certain cases, where BBCode-style tags supported by a custom dialect are treated as reference definitions instead, e.g. `[b]label[/b]: description`.

Ported from https://github.com/discourse/discourse/pull/2731.
