### PR TITLE
Don't convert ampersands when they form part of an HTML entity

### DIFF
--- a/src/render_tree.js
+++ b/src/render_tree.js
@@ -90,7 +90,7 @@ define(['./core', './markdown_helpers'], function(Markdown, MarkdownHelpers) {
 
   function escapeHTML( text ) {
     if (text && text.length > 0) {
-      return text.replace( /&/g, "&amp;" )
+      return text.replace( /&(?!\w+;)/g, "&amp;" )
                  .replace( /</g, "&lt;" )
                  .replace( />/g, "&gt;" )
                  .replace( /"/g, "&quot;" )

--- a/test/render_tree.t.js
+++ b/test/render_tree.t.js
@@ -32,3 +32,15 @@ tap.test("intermediate trees left alone", function(t) {
 
   t.end();
 });
+
+tap.test("non-entity ampersand escaped", function(t) {
+  var tree = markdown.renderJsonML( ['html', ['p', {style: undefined }, 'AT&T'] ] );
+  t.equivalent( tree, '<p>AT&amp;T</p>' );
+  t.end();
+});
+
+tap.test("entity ampersand not escaped", function(t) {
+  var tree = markdown.renderJsonML( ['html', ['p', {style: undefined }, 'x &lt; y'] ] );
+  t.equivalent( tree, '<p>x &lt; y</p>' );
+  t.end();
+});


### PR DESCRIPTION
The mardown spec allows for the use HTML entities.

The current markdown-js always converts '&' into '&amp;'.

This patch allows 'AT&T' and 'X &lt; Y' to work as intended.