### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,7 @@
   "bugs": {
     "url": "https://github.com/evilstreak/markdown-js/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/evilstreak/markdown-js.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/