### PR TITLE
Example in READEME for how to use markdown.js in browser is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ It also works in a browser; here is a complete example:
     <div id="preview"> </div>
     <script src="lib/markdown.js"></script>
     <script>
+    var markdown = {};
+    markdownFactory(markdown);
       function Editor(input, preview) {
         this.update = function () {
           preview.innerHTML = markdown.toHTML(input.value);

--- a/inc/footer-node.js
+++ b/inc/footer-node.js
@@ -6,4 +6,4 @@
   expose.renderJsonML = Markdown.renderJsonML;
   expose.DialectHelpers = DialectHelpers;
 
-})(exports);
+};

--- a/inc/header.js
+++ b/inc/header.js
@@ -8,4 +8,4 @@
  * Date: @DATE
  */
 
-(function(expose) {
+markdownFactory = function(expose) {


### PR DESCRIPTION
- If we follow the readme to use this markdown.js in browser, It will
not be useful, return 'expose is undefined' and 'markdown is
undefined',so i change some code in this html in READEME and
lib/markdown.js.
- It maybe not be wrong in old way which READEME described, it may be
used in node environment,not run in just simply browser + html + js
- I change some code ,so i could use it