### PR TITLE
Fixes formatting in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ and testing don't work on older versions of node. That said since this module
 is so simple and doesn't use any parts of the node API if you use the pre-built
 version and find a bug let us know and we'll try and fix it.
 
-### Browser
+### Browser
 
 It also works in a browser; here is a complete example:
 


### PR DESCRIPTION
Don't know why but formatting for the header wasn't working.

Replacing the space with a new space seems to fix it, view the rich text diff to see the difference.