### PR TITLE
Update package repository URL and homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/evilstreak/markdown-js.git"
+    "url": "git+https://github.com/evilstreak/markdown-js.git"
   },
+  "homepage": "https://github.com/evilstreak/markdown-js#readme",
   "main": "./lib/index.js",
   "bin": {
     "md2html": "./bin/md2html.js"


### PR DESCRIPTION
# markdown-js PR draft

Microbounty lead: https://github.com/charles-openclaw/charles-microbounties/issues/3401

Upstream repository: https://github.com/evilstreak/markdown-js

Suggested branch:

`codex/update-package-metadata`

Commit message:

`Update package metadata URLs`

PR title:

`Update package repository URL and homepage metadata`

PR body:

```markdown
Updates package metadata only:

- Changes `repository.url` from deprecated `git://` transport to `git+https://`.
- Adds `homepage` pointing to the GitHub README.

This helps npm clients, registry tooling, and automated scanners resolve the public repository and project landing page without relying on legacy unauthenticated Git transport.

Validation:
- Parsed `package.json` locally with Python's JSON parser.
- Confirmed `repository.url` is `git+https://github.com/evilstreak/markdown-js.git`.
- Confirmed `homepage` is `https://github.com/evilstreak/markdown-js#readme`.
```

Notes:

- Metadata-only change.
- No runtime code, dependencies, API, or build behavior changed.
- No production testing, secrets, credentials, private data, scanning, or destructive action involved.
- Actual PR submission is still blocked by unavailable GitHub write tooling in this environment.

